### PR TITLE
bug fix: More Flexible Github Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ my-release-log-step:
 - `github_tag_id` - you can use this as regex to match on specific tags.
 - `slack_channel`/`SLACK_URL` - when using the API, you should use `slack_channel` to specify which room you'd like to post to. When using `SLACK_URL` you should not specify the room (i.e. `slack_channel`) because the room is already a part of the webhook. ([Setting Up A Webhook (e.g. SLACK_URL)](https://api.slack.com/incoming-webhooks), [Setting Up A Slack Token](https://api.slack.com/docs/token-types#verification))
 - `teams` - a list of teams which allows you to organize the output of Captains Log into meaningful chunks. (more below)
+- `enterprise_host` - if you use Enterprise Github, this is where you would supply the custom domain. (e.g. https://git.myCompany.com)
 
 **Example of `github_tag_id`**
 

--- a/config/default.json
+++ b/config/default.json
@@ -4,7 +4,7 @@
     "timeout": 0,
     "token": "<REPLACE_ME>",
     "host": "https://github.com/api/v3",
-    "domain": "https://github.com"
+    "domain": null
   },
   "slack": {
     "channel": "<REPLACE_ME>",

--- a/src/config.js
+++ b/src/config.js
@@ -48,7 +48,7 @@ nconf.set('development', process.env.NODE_ENV === DEVELOPMENT);
 nconf.set('regexp', process.env.PLUGIN_REGEXP);
 
 // Github
-nconf.set('github:domain', process.env.PLUGIN_GITHUB_DOMAIN);
+nconf.set('github:domain', process.env.PLUGIN_ENTERPRISE_HOST);
 nconf.set('github:host', process.env.PLUGIN_GITHUB_HOST);
 nconf.set('github:token', process.env.GITHUB_TOKEN);
 nconf.set('github:owner', process.env.PLUGIN_GITHUB_OWNER);

--- a/src/connectors/GithubConnector.js
+++ b/src/connectors/GithubConnector.js
@@ -1,7 +1,12 @@
 const Github = require('@octokit/rest');
 const config = require('../config');
 
-const { host, timeout, token } = config.get('github');
+const {
+  domain,
+  host,
+  timeout,
+  token,
+} = config.get('github');
 
 const accepts = [
   'application/vnd.github.v3+json',
@@ -18,7 +23,7 @@ const github = new Github({
     accept: accepts.join(','),
     'user-agent': 'octokit/rest v15.8.1',
   },
-  baseUrl: host,
+  baseUrl: domain || host,
 });
 
 github.authenticate({


### PR DESCRIPTION
This should allow people to pass in `PLUGIN_ENTERPRISE_HOST` as a value.

The only time people would want this feature is if they're working on a company Github. It's a different domain.