### PR TITLE
Feature: Details will show PR Titles

### DIFF
--- a/src/facades/ReleaseCommunicationFacade.js
+++ b/src/facades/ReleaseCommunicationFacade.js
@@ -80,11 +80,11 @@ class ReleaseCommunication {
     const pullRequestMessages = pullRequests.map((pr) => {
       const noCommentBody = pr.body.replace(PR_TEMPLATE_COMMENT_REGEX, '');
       const jiraTickets = uniq(groupFinder(JIRA_REGEX, noCommentBody) || []);
-
       return {
         number: pr.number,
         message: pr.body,
         jiraTickets,
+        title: pr.title,
       };
     });
 

--- a/src/facades/__fixtures__/pullRequestResponse.json
+++ b/src/facades/__fixtures__/pullRequestResponse.json
@@ -1,5 +1,6 @@
 {
   "number": 1,
+  "title": "bla",
   "body":
     "Nonesense test\r\nasdfasdf;lkj\r\n[JIRA-1234](https://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad`"
 }

--- a/src/facades/__fixtures__/pullRequestResponseRawLink.json
+++ b/src/facades/__fixtures__/pullRequestResponseRawLink.json
@@ -1,5 +1,6 @@
 {
   "number": 1,
+  "title": "bla",
   "body":
     "Nonesense test\r\nasdfasdf;lkj\r\nhttps://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad`"
 }

--- a/src/facades/__tests__/ReleaseCommunicationFacade.test.js
+++ b/src/facades/__tests__/ReleaseCommunicationFacade.test.js
@@ -39,6 +39,7 @@ describe('ReleaseCommunicationFacade', () => {
         jiraTickets: ['JIRA-1234'],
         message: pullRequestResponse.body,
         number: 1,
+        title: 'bla',
       },
     ];
 
@@ -54,6 +55,7 @@ describe('ReleaseCommunicationFacade', () => {
         jiraTickets: ['JIRA-1234'],
         message: pullRequestResponseRawLink.body,
         number: 1,
+        title: 'bla',
       },
     ];
 

--- a/src/factories/Message/__tests__/Message.test.js
+++ b/src/factories/Message/__tests__/Message.test.js
@@ -9,6 +9,7 @@ describe('Message', () => {
     issueTracking: { jira: { teams: ['ACCOUNTING', 'ASSISTANT_TO_THE_REGIONAL_MANAGER'] } },
     mentions: '@Dwight.K.Schrute @Michael.J.Scott @Pam.Beasley',
     messages: 'Where is Michael Scarn!?',
+    titles: 'No. NOOOOO.',
   });
 
   it('should create a default Message object', () => {
@@ -44,8 +45,8 @@ describe('Message', () => {
         },
         {
           short: true,
-          title: expect.any(String),
-          value: expect.any(String),
+          title: 'Details',
+          value: 'No. NOOOOO.',
         },
       ],
     }));

--- a/src/factories/Message/index.js
+++ b/src/factories/Message/index.js
@@ -1,8 +1,8 @@
 const Message = function Message(type = 'slack', team = {}) {
   const {
-    color = '#3ef2c5', mentions = '', emoji = '🌱', teamMessages = '', name = 'General',
+    color = '#3ef2c5', mentions = '', emoji = '🌱', teamMessages = '', name = 'General', teamTitles = '',
   } = team;
-  const teamTitle = `${name} ${emoji}`;
+  const teamName = `${name} ${emoji}`;
 
   const generateSlack = function generateSlack(message = '') {
     if (!teamMessages && !message) return '';
@@ -17,7 +17,7 @@ const Message = function Message(type = 'slack', team = {}) {
         },
         {
           title: 'Details',
-          value: '... coming soon',
+          value: teamTitles,
           short: true,
         },
       ];
@@ -26,7 +26,7 @@ const Message = function Message(type = 'slack', team = {}) {
     return {
       fallback: teamMessages || message,
       color,
-      title: teamTitle,
+      title: teamName,
       text: mentions,
       fields,
     };

--- a/src/factories/Team/__tests__/Team.test.js
+++ b/src/factories/Team/__tests__/Team.test.js
@@ -59,4 +59,14 @@ describe('Team', () => {
 
     expect(team.teamMessages).toEqual('Hi\n Bye');
   });
+
+  it('should add a title to existing titles', () => {
+    const team = Team({ ...exampleTeam, titles: 'This Is A Title' });
+
+    expect(team.teamTitles).toEqual('This Is A Title');
+
+    team.addMessage('', 'Bye');
+
+    expect(team.teamTitles).toEqual('This Is A Title\n Bye');
+  });
 });

--- a/src/factories/Team/index.js
+++ b/src/factories/Team/index.js
@@ -1,10 +1,11 @@
 const IssueTracker = require('./IssueTracker');
+const { truncate } = require('../../utils');
 
 const Team = function Team(team = {}) {
   const {
-    color = '#3ef2c5', emoji = '🌱', issueTracking = {}, mentions = '', messages = '', name = 'General',
+    color = '#3ef2c5', emoji = '🌱', issueTracking = {}, mentions = '', messages = '', titles = '', name = 'General',
   } = team;
-
+  this.teamTitles = titles;
   this.teamMessages = messages;
 
   const trackers = IssueTracker(issueTracking);
@@ -19,8 +20,10 @@ const Team = function Team(team = {}) {
     return isMatch;
   };
 
-  const addMessage = function addMessage(message = '') {
+  const addMessage = function addMessage(message = '', title = '') {
     const msg = `${this.teamMessages.length ? `\n ${message}` : message}`;
+    const t = `${this.teamTitles.length ? `\n ${truncate(title)}` : truncate(title)}`;
+    this.teamTitles = this.teamTitles.concat(t);
     this.teamMessages = this.teamMessages.concat(msg);
     return this.teamMessages;
   };
@@ -33,6 +36,7 @@ const Team = function Team(team = {}) {
     messageMatch,
     mentions,
     teamMessages: this.teamMessages,
+    teamTitles: this.teamTitles,
     ...trackers,
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,12 @@ const createAttachment = (hasMessages) => {
 const formatChangeMessage = ({
   change = {}, owner, repo, jiraTeam, githubDomain,
 }) => {
-  const { jiraTickets, number } = change;
+  const { jiraTickets, number, title } = change;
   if (!jiraTickets.length) return null;
   return jiraTickets.map(ticket => ({
     message: `<https://jira.${jiraTeam}.com/browse/${ticket}|[${ticket}]> - <${githubDomain}/${owner}/${repo}/pull/${number}|#${number}>`,
     name: ticket,
+    title,
   }));
 };
 
@@ -83,7 +84,6 @@ module.exports = async function App(config) {
   populateMessages(defaultTeam)(teamList, sortedMessages);
 
   const { message, attachments } = createAttachment(messages.length);
-
   logger.info(message, JSON.stringify(attachments));
 
   await releaseCommunication.sendMessage(message, attachments);

--- a/src/utils/__tests__/populateMessages.test.js
+++ b/src/utils/__tests__/populateMessages.test.js
@@ -5,9 +5,11 @@ describe('populateMessages', () => {
   const messages = [
     {
       message: 'CHANDLER-123: The one with the wedding',
+      title: 'bugfix: find missing Chandler',
     },
     {
       message: 'JOEY-4345: The one with the duck',
+      title: 'ducks!!!',
     },
   ];
 
@@ -43,9 +45,16 @@ describe('populateMessages', () => {
     expect(exampleTeam.teamMessages).toEqual(messages[0].message);
   });
 
-  it('should add messages to default team if no team bucket exist', () => {
+  it('should assign team titles if given teams and relevant team titles', () => {
     populateMessages(defaultTeam)([exampleTeam], messages);
 
-    expect(defaultTeam.teamMessages).toEqual(messages[1].message);
+    expect(exampleTeam.teamTitles).toEqual(messages[0].title);
+  });
+
+
+  it('should add titles to default team if no team bucket exist', () => {
+    populateMessages(defaultTeam)([exampleTeam], messages);
+
+    expect(defaultTeam.teamTitles).toEqual(messages[1].title);
   });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ const groupFinder = require('./groupFinder');
 const getTagDiffFromTagId = require('./getTagDiffFromTagId');
 const teamHelper = require('./teamHelper');
 const nameSort = require('./nameSort');
+const truncate = require('./truncate');
 const populateMessages = require('./populateMessages');
 
 module.exports = {
@@ -10,4 +11,5 @@ module.exports = {
   nameSort,
   populateMessages,
   teams: teamHelper,
+  truncate,
 };

--- a/src/utils/populateMessages.js
+++ b/src/utils/populateMessages.js
@@ -5,17 +5,16 @@ const populateMessages = function populateMessages(defaultTeam) {
     let filteredMessages = messages;
 
     if (teamsToPopulate.length === 0) {
-      filteredMessages.forEach(({ message = '' }) => defaultTeam.addMessage(message));
+      filteredMessages.forEach(({ message = '', title = '' }) => defaultTeam.addMessage(message, title));
       return true;
     }
 
     const [team, ...remainingTeams] = teamsToPopulate;
 
-    filteredMessages = messages.filter(({ message = '' }) => {
+    filteredMessages = messages.filter(({ message = '', title = '' }) => {
       if (team.messageMatch(message)) {
-        team.addMessage(message);
+        team.addMessage(message, title);
       }
-
       return !team.messageMatch(message);
     });
 

--- a/src/utils/truncate.js
+++ b/src/utils/truncate.js
@@ -1,0 +1,9 @@
+const truncate = (str, length = 34) => {
+  // https://www.w3resource.com/javascript-exercises/javascript-string-exercise-16.php
+  const ending = '...';
+  return (
+    str.length > length ? str.substring(0, length - ending.length) + ending : str
+  );
+};
+
+module.exports = truncate;


### PR DESCRIPTION
### Proposed UX
![image](https://user-images.githubusercontent.com/11198076/44355422-2e035f00-a472-11e8-937e-cb0cc0dbe8f8.png)

### Summary
Right now we're showing `coming soon...` under the details section. Let's make that section more useful.

We scrape the title from the PR, and use that as a nice one-sentence description of each PR.

- [x] Tests have been updated. 

For my next trick ✨, you'll see a follow up PR that allows an optional `stripCommitType`. Then we can remove `feature:`, `bugfix:`, and the like if the user so chooses.
