### PR TITLE
fix: Github Host Confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ my-release-log-step:
 - `github_tag_id` - you can use this as regex to match on specific tags.
 - `slack_channel`/`SLACK_URL` - when using the API, you should use `slack_channel` to specify which room you'd like to post to. When using `SLACK_URL` you should not specify the room (i.e. `slack_channel`) because the room is already a part of the webhook. ([Setting Up A Webhook (e.g. SLACK_URL)](https://api.slack.com/incoming-webhooks), [Setting Up A Slack Token](https://api.slack.com/docs/token-types#verification))
 - `teams` - a list of teams which allows you to organize the output of Captains Log into meaningful chunks. (more below)
-- `enterprise_host` - if you use Enterprise Github, this is where you would supply the custom domain. (e.g. https://git.myCompany.com)
+- `enterprise_host` - if you use Enterprise Github, this is where you would supply the custom domain. (e.g. https://git.myCompany.com, `/api/v3` will be appended to this **do not include it for this value**).
 
 **Example of `github_tag_id`**
 

--- a/src/connectors/GithubConnector.js
+++ b/src/connectors/GithubConnector.js
@@ -2,10 +2,7 @@ const Github = require('@octokit/rest');
 const config = require('../config');
 
 const {
-  domain,
-  host,
-  timeout,
-  token,
+  domain, host, timeout, token,
 } = config.get('github');
 
 const accepts = [
@@ -23,7 +20,7 @@ const github = new Github({
     accept: accepts.join(','),
     'user-agent': 'octokit/rest v15.8.1',
   },
-  baseUrl: domain || host,
+  baseUrl: `${domain}/api/v3` || host,
 });
 
 github.authenticate({


### PR DESCRIPTION
There was a little confusion around how `enterpris_host` was working. Since we're locked into a github api version, we elected to just hardcode the `api/v3` into the connector. 