### PR TITLE
fix: Jira Regex Should Support Numbers

### DIFF
--- a/src/facades/ReleaseCommunicationFacade.js
+++ b/src/facades/ReleaseCommunicationFacade.js
@@ -11,7 +11,7 @@ const {
 const { groupFinder, getTagDiffFromTagId } = require('../utils');
 
 const PR_TEMPLATE_COMMENT_REGEX = new RegExp(/<!--[\s\S]*?-->/, 'gm');
-const regex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([A-Z]+-[0-9]+)\]?/;
+const regex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([A-Z0-9]+-[0-9]+)\]?/;
 const JIRA_REGEX = new RegExp(regex, 'g');
 const SQUASH_PR_REGEX = new RegExp(/\(#(.*)\)/, 'g');
 

--- a/src/facades/__fixtures__/pullRequestResponse.json
+++ b/src/facades/__fixtures__/pullRequestResponse.json
@@ -2,5 +2,5 @@
   "number": 1,
   "title": "bla",
   "body":
-    "Nonesense test\r\nasdfasdf;lkj\r\n[JIRA-1234](https://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad`"
+    "Nonesense test\r\nasdfasdf;lkj\r\n[JIRA-1234](https://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad` https://jira.bla.com/browse/JIRA2-3455"
 }

--- a/src/facades/__fixtures__/pullRequestResponseRawLink.json
+++ b/src/facades/__fixtures__/pullRequestResponseRawLink.json
@@ -2,5 +2,5 @@
   "number": 1,
   "title": "bla",
   "body":
-    "Nonesense test\r\nasdfasdf;lkj\r\nhttps://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad`"
+    "Nonesense test\r\nasdfasdf;lkj\r\nhttps://jira.bla.com/browse/JIRA-1234)\r\n\r\nTestingasdf;lkj\r\n\r\n```Code```\r\n\r\n``codebad` https://jira.bla.com/browse/JIRA2-3455"
 }

--- a/src/facades/__tests__/ReleaseCommunicationFacade.test.js
+++ b/src/facades/__tests__/ReleaseCommunicationFacade.test.js
@@ -38,7 +38,7 @@ describe('ReleaseCommunicationFacade', () => {
     const diff = await RC.parseDiff(squashDiffResponse);
     const expectedDiff = [
       {
-        jiraTickets: ['JIRA-1234'],
+        jiraTickets: ['JIRA-1234', 'JIRA2-3455'],
         message: pullRequestResponse.body,
         number: 1,
         title: 'bla',
@@ -71,7 +71,7 @@ describe('ReleaseCommunicationFacade', () => {
     const diff = await RC.parseDiff(squashDiffResponse);
     const expectedDiff = [
       {
-        jiraTickets: ['JIRA-1234'],
+        jiraTickets: ['JIRA-1234', 'JIRA2-3455'],
         message: pullRequestResponseRawLink.body,
         number: 1,
         title: 'bla',


### PR DESCRIPTION
We were not supporting team names like `JIRA2-1234` which is perfectly valid. This will allow teams to use any valid Jira name for their tickets. 