### PR TITLE
Slack Formatting Whitespace Fix

### DIFF
--- a/src/factories/Team/__tests__/Team.test.js
+++ b/src/factories/Team/__tests__/Team.test.js
@@ -90,10 +90,13 @@ describe('Team', () => {
 
     expect(team.teamTitles).toEqual('This Is A Title');
 
-    team.addMessage('', 'title that is really long and far over 70 characters. We should be truncating this very soon');
+    team.addMessage(
+      '',
+      'title that is really long and far over lots characters. We should be truncating this very soon',
+    );
 
-    expect(team.teamTitles).toEqual('This Is A Title\n title that is really long and far over 70 characters. We ...');
-    expect(team.teamMessages).toEqual(' \n');
+    expect(team.teamTitles).toEqual('This Is A Title\n title that is really long and far over lots characte...');
+    expect(team.teamMessages).toEqual(' \n ');
   });
 
   it('should wrap a message and add a new line to the title if message does not need to wrap', () => {
@@ -105,6 +108,6 @@ describe('Team', () => {
     team.addMessage('message that is really long and far over 105 characters. We are fun fun fun, in the sun sun sun #realyLongText');
 
     expect(team.teamMessages).toEqual('This Is A Message\n message that is really long and far over 105 characters. We are fun fun fun, in the sun sun sun #realyLongText');
-    expect(team.teamTitles).toEqual(' \n');
+    expect(team.teamTitles).toEqual(' \n ');
   });
 });

--- a/src/factories/Team/index.js
+++ b/src/factories/Team/index.js
@@ -29,11 +29,11 @@ const Team = function Team(team = {}) {
   const addMessage = function addMessage(message = '', title = '', githubPr = '') {
     // Slack lines wrap after ~36 characters. Most formatted messages will
     // include links so we'll say we're wrapping at higher char counts
-    const hasMessageWrap = message.length > 105;
+    const hasMessageWrap = message.length > 90;
     // Titles will have PR Numbers in them, so we'll give them a little less before truncating
-    const hasTitleWrap = title.length > 59;
+    const hasTitleWrap = title.length > 30;
 
-    const formattedTitle = hasTitleWrap ? truncate(title, 60) : title;
+    const formattedTitle = hasTitleWrap ? truncate(title, 55) : title;
 
     const details = githubPr ? `${githubPr}: ${formattedTitle}` : formattedTitle;
 
@@ -45,11 +45,11 @@ const Team = function Team(team = {}) {
 
     if (hasMessageWrap && !hasTitleWrap) {
       messageStories = `${messageStories}`;
-      messageDetails = `${messageDetails} \n`;
+      messageDetails = `${messageDetails} \n `;
     }
 
     if (!hasMessageWrap && hasTitleWrap) {
-      messageStories = `${messageStories} \n`;
+      messageStories = `${messageStories} \n `;
       messageDetails = `${messageDetails}`;
     }
 


### PR DESCRIPTION
There were some slight issues with formatting that were semi-expected. We'd set arbitrary limits on the wrap and truncate portions of our team `addMessage`. This has been addressed and all limits have been restricted even further. This should help format all messages on slack correctly and add white space where needed.

closes #20 