### PR TITLE
fix: update Jira issue regex to no leading number

### DIFF
--- a/src/utils/ticketFinder/__fixtures__/mockBody.js
+++ b/src/utils/ticketFinder/__fixtures__/mockBody.js
@@ -11,6 +11,27 @@ const mockBodyWithTickets = `
   https://github.com/owner/repo/issues/123
 `;
 
+const mockBodyWithTicketsInBrackets = `
+  This is a body with tickets from:
+
+  JIRA
+  ===
+  [CAT-123]
+
+  GITHUB
+  ===
+
+  https://github.com/owner/repo/issues/123
+`;
+
+const mockBodyWithTicketLikeThings = `
+  This is a body with:
+
+  [2018-10]
+  [0CAT-123]
+  [CAT-01]
+`;
+
 const mockBodyWithMultipleTickets = `
   This is a body with tickets from:
 
@@ -30,6 +51,8 @@ const mockBodyWithNothing = '';
 
 module.exports = {
   mockBodyWithTickets,
+  mockBodyWithTicketsInBrackets,
+  mockBodyWithTicketLikeThings,
   mockBodyWithMultipleTickets,
   mockBodyWithNothing,
 };

--- a/src/utils/ticketFinder/finders/jira/index.js
+++ b/src/utils/ticketFinder/finders/jira/index.js
@@ -3,7 +3,7 @@ const nconf = require('nconf');
 
 const { groupFinder } = require('../../../');
 
-const regex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([A-Z0-9]+-[0-9]+)\]?/;
+const regex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([[A-Z][A-Z0-9]*-[1-9][0-9]*)\]?/;
 const JIRA_REGEX = new RegExp(regex, 'g');
 
 const jiraFinder = (body) => {


### PR DESCRIPTION
Updates the default Jira issue regex to disallow leading numbers on project keys, and to require non-zero-prefixed issue numbers. This is customizable anyway in case anyone in the wild uses only numbers for their project key, but it's a more sane default with less false positives (such as `YYYY-MM` dates surrounded by brackets) that aligns more closely to [the apparent Jira default of requiring two uppercase letters](https://confluence.atlassian.com/display/JIRA041/Configuring+Project+Keys).
