### PR TITLE
test: add for jira brackets and false positives

### DIFF
--- a/src/utils/ticketFinder/__fixtures__/mockBody.js
+++ b/src/utils/ticketFinder/__fixtures__/mockBody.js
@@ -17,11 +17,6 @@ const mockBodyWithTicketsInBrackets = `
   JIRA
   ===
   [CAT-123]
-
-  GITHUB
-  ===
-
-  https://github.com/owner/repo/issues/123
 `;
 
 const mockBodyWithTicketLikeThings = `

--- a/src/utils/ticketFinder/__tests__/ticketFinder.test.js
+++ b/src/utils/ticketFinder/__tests__/ticketFinder.test.js
@@ -1,5 +1,11 @@
 const ticketFinder = require('..');
-const { mockBodyWithTickets, mockBodyWithNothing, mockBodyWithMultipleTickets } = require('../__fixtures__/mockBody');
+const {
+  mockBodyWithTickets,
+  mockBodyWithTicketsInBrackets,
+  mockBodyWithTicketLikeThings,
+  mockBodyWithMultipleTickets,
+  mockBodyWithNothing,
+} = require('../__fixtures__/mockBody');
 
 describe('ticketFinder', () => {
   it('should find tickets for all finders given a message body', async () => {
@@ -19,6 +25,21 @@ describe('ticketFinder', () => {
       },
       jira: { name: 'jira', tickets: [{ name: 'CAT-123' }] },
     });
+  });
+
+  it('should find Jira tickets in brackets in given a message body', async () => {
+    const tickets = await ticketFinder(mockBodyWithTicketsInBrackets);
+
+    expect(tickets).toEqual({
+      github: { name: 'github', tickets: [] },
+      jira: { name: 'jira', tickets: [{ name: 'CAT-123' }] },
+    });
+  });
+
+  it('should not find things that look almost like tickets in given a message body', async () => {
+    const tickets = await ticketFinder(mockBodyWithTicketLikeThings);
+
+    expect(tickets).toEqual({ github: { name: 'github', tickets: [] }, jira: { name: 'jira', tickets: [] } });
   });
 
   it('should find multiple tickets for all finders given a message body', async () => {


### PR DESCRIPTION
Adds some additional tests for the Jira issue bracket syntax and also for the false positives prevented by #22.