### PR TITLE
Add Slack Message Formatting Url To Console Output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const logger = require('./logger');
 const Team = require('./factories/Team');
 const Message = require('./factories/Message');
 const {
-  populateMessages, teams, nameSort, formatMessages,
+  populateMessages, teams, nameSort, formatMessages, generateSlackFormatterUrl,
 } = require('./utils');
 
 const defaultTeam = Team();
@@ -75,7 +75,8 @@ module.exports = async function App(config) {
   populateMessages(defaultTeam)(teamList, sortedMessages);
 
   const { message, attachments } = createAttachment(messages.length);
-  logger.info(message, JSON.stringify(attachments));
+
+  logger.info(`\n Slack Formatter Url. CMD+Click to open in your default browser \n \n ${generateSlackFormatterUrl(attachments)}`);
 
   await releaseCommunication.sendMessage(message, attachments);
 };

--- a/src/utils/__tests__/generateSlackFormatterUrl.test.js
+++ b/src/utils/__tests__/generateSlackFormatterUrl.test.js
@@ -1,0 +1,16 @@
+const querystring = require('querystring');
+const generateSlackFormatterUrl = require('../generateSlackFormatterUrl');
+
+describe('generateSlackFormatterUrl', () => {
+  it('should create a url that links to slack message formatter', () => {
+    const fakeAttachments = [{ fallback: 'asdf', fields: [{ title: 'Funky', value: 'Ooops', short: true }] }];
+    const expectedResult =
+      'https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22fallback%22%3A%22asdf%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22Funky%22%2C%22value%22%3A%22Ooops%22%2C%22short%22%3Atrue%7D%5D%7D%5D%7D'; // eslint-disable-line
+
+    const result = generateSlackFormatterUrl(fakeAttachments);
+    const parsedResult = JSON.parse(Object.values(querystring.parse(result)));
+
+    expect(result).toEqual(expectedResult);
+    expect(parsedResult.attachments).toEqual(fakeAttachments);
+  });
+});

--- a/src/utils/generateSlackFormatterUrl.js
+++ b/src/utils/generateSlackFormatterUrl.js
@@ -1,0 +1,15 @@
+const querystring = require('querystring');
+
+const generateSlackFormatterUrl = (attachments) => {
+  const baseSlackUrl = 'https://api.slack.com/docs/messages/builder?';
+
+  const attachmentsToStringify = JSON.stringify({
+    attachments,
+  });
+
+  const stringifiedQuery = querystring.stringify({ msg: attachmentsToStringify });
+
+  return `${baseSlackUrl}${stringifiedQuery}`;
+};
+
+module.exports = generateSlackFormatterUrl;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,9 +6,11 @@ const truncate = require('./truncate');
 const populateMessages = require('./populateMessages');
 const ticketFinder = require('./ticketFinder');
 const formatMessages = require('./formatMessages');
+const generateSlackFormatterUrl = require('./generateSlackFormatterUrl');
 
 module.exports = {
   groupFinder,
+  generateSlackFormatterUrl,
   getTagDiffFromTagId,
   formatMessages,
   nameSort,


### PR DESCRIPTION
closes #19

This was a great idea from @remoz. We were copy and pasting the attachments from the console to the browser to test if Captain's Log output was correct. This will make it so you can open up the Slack Message Formatter URL directly from console.