### PR TITLE
Fix: Multiple Issue Trackers Sending Message to Default

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
----
-  extends: airbnb
-  env:
-    jest: true
-  rules:
-    max-len: ['error', 150]
+{
+  "extends": "airbnb",
+  "env": {
+    "jest": true
+  },
+  "rules": {
+    "max-len": ["error", 150]
+  }
+}

--- a/src/factories/Team/__tests__/Team.test.js
+++ b/src/factories/Team/__tests__/Team.test.js
@@ -51,11 +51,22 @@ describe('Team', () => {
     expect(team.messageMatch('<https://github.com/my_owner/my_repo/issues/3|example_user/example_project/#3> - <https://github.com/tester/project/pull/2|#2')).toEqual(true);
   });
 
+  it('should match on a message mentioning a team with multiple issue trackers', () => {
+    const team = Team({
+      ...exampleTeam,
+      issueTracking: { github: { projects: ['my_owner/my_repo'] } },
+      jira: { projects: ['TEST'] },
+    });
+
+    expect(team.messageMatch('<https://github.com/my_owner/my_repo/issues/3|example_user/example_project/#3> - <https://github.com/tester/project/pull/2|#2')).toEqual(true);
+  });
+
   it('should not match on a github message not mentioning a team', () => {
     const team = Team({ ...exampleTeam, issueTracking: { github: { projects: ['my_owner/my_repo'] } } });
 
     expect(team.messageMatch('<https://github.com/test/project/issues/3|example_user/example_project/#3> - <https://github.com/my_owner/my_repo/pull/2|#2')).toEqual(false);
   });
+
   it('should not match on a message not mentioning a team', () => {
     const team = Team(exampleTeam);
 

--- a/src/factories/Team/index.js
+++ b/src/factories/Team/index.js
@@ -17,13 +17,18 @@ const Team = function Team(team = {}) {
   const trackers = IssueTracker(issueTracking);
 
   const messageMatch = (message = '') => {
-    let isMatch = false;
+    const isMatch = Object.values(trackers).reduce((acc, tracker) => {
+      const { matches = [] } = tracker;
+      const match = matches.filter(matcher => message.match(matcher));
 
-    Object.values(trackers).forEach(({ matches = [] }) => {
-      isMatch = !!matches.filter(match => message.match(match)).length;
-    });
+      if (match.length) {
+        return [...acc, ...match];
+      }
 
-    return isMatch;
+      return acc;
+    }, []);
+
+    return !!isMatch.length;
   };
 
   const addMessage = function addMessage(message = '', title = '', githubPr = '') {


### PR DESCRIPTION
This was an oversight in the original design of the trackers. Instead of looking for a single match, we were looking to see if _everything_ matched. This isn't intended behavior when a team is using multiple trackers. 

Matchers will now look for any single match and mark the match as true.

### Issues
closes #29