### PR TITLE
Fix: Empty PR Body Error

### DIFF
--- a/src/facades/ReleaseCommunicationFacade.js
+++ b/src/facades/ReleaseCommunicationFacade.js
@@ -93,14 +93,17 @@ class ReleaseCommunication {
     const pullRequests = await Promise.all(uniquePRNumbers.map(async prNum => getPullRequestHandler(this.owner, this.repo, prNum)));
 
     const pullRequestMessages = Promise.all(pullRequests.map(async (pr) => {
-      const stripIgnoreTickets = pr.body.replace(STRIP_IGNORE_TICKETS, '');
+      // Initialize body in case the PR description is empty.
+      const body = pr.body || '';
+
+      const stripIgnoreTickets = body.replace(STRIP_IGNORE_TICKETS, '');
       const noCommentBody = stripIgnoreTickets.replace(PR_TEMPLATE_COMMENT_REGEX, '');
 
       const ticketGroups = await ticketFinder(noCommentBody);
 
       return {
         number: pr.number,
-        message: pr.body,
+        message: body,
         ...ticketGroups,
         title: pr.title,
       };

--- a/src/facades/__tests__/ReleaseCommunicationFacade.test.js
+++ b/src/facades/__tests__/ReleaseCommunicationFacade.test.js
@@ -50,6 +50,23 @@ describe('ReleaseCommunicationFacade', () => {
     expect(diff).toEqual(expectedDiff);
   });
 
+  it('should parse a diff response when a pull request has no body', async () => {
+    expect.assertions(1);
+    handlers.getPullRequestHandler.mockResolvedValueOnce({ ...pullRequestResponse, body: null });
+    const diff = await RC.parseDiff(squashDiffResponse);
+    const expectedDiff = [
+      {
+        github: { name: 'github', tickets: [] },
+        jira: { name: 'jira', tickets: [] },
+        message: '',
+        number: 1,
+        title: 'bla',
+      },
+    ];
+
+    expect(diff).toEqual(expectedDiff);
+  });
+
   it('should handle the retrieval and parse of non-squashed commits', async () => {
     expect.assertions(2);
     handlers.getTagsHandler.mockResolvedValue(tagResponse);

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ module.exports = async function App(config) {
 
   populateMessages(defaultTeam)(teamList, sortedMessages);
 
-  const { message, attachments, subChannelAttachments } = createAttachment(messages.length, { owner, repo });
+  const { message, attachments, subChannelAttachments = [] } = createAttachment(messages.length, { owner, repo });
 
   logger.info(`\n Slack Formatter Url. CMD+Click to open in your default browser \n \n ${generateSlackFormatterUrl(attachments)}`);
 


### PR DESCRIPTION
When a pull request body was _empty_ it would leave `pr.body` as a `null` value. This would result in `TypeError: Cannot read property 'replace' of null` since it is not a string. We're just defaulting the value of `pr.body` to be an empty string here in that case. 

Also fixed: there was a non-breaking error when you would not list any `sub-teams` in your `.drone.yml` and it would result in `ERROR (...): Cannot read property 'length' of undefined`. This was fixed with a simple defaulting of the array. 