### PR TITLE
Jira Branch Name Convention Support

### DIFF
--- a/docs/pr-body/README.md
+++ b/docs/pr-body/README.md
@@ -2,13 +2,15 @@
 
 In order for Captain's log to pick up any issues addressed in a pull request, you must include them in the pull request body.
 
+**Note:** If you are using Jira, Captain's Log supports the branch name convention outlined [here](https://confluence.atlassian.com/jirasoftwarecloud/referencing-issues-in-your-development-work-777002789.html). You may include something like `myusername/JIRA-123` or `JIRA-123` as your branch name, and Captain's Log will pick that up along with all issues in the body.
+
 ### How to get Captain's Log to pick up an issue
 
 For example:
 
 ![ ](../static/pr-example.png)
 
-The linking of _#34_ in the pull request will automatically get picked up by Captain's Log. 
+The linking of _#34_ in the pull request will automatically get picked up by Captain's Log.
 
 The same goes for all of the github keywords, like "closes #34" (etc.).
 
@@ -24,11 +26,11 @@ This PR addresses concerns brought up in [JIRA-234](https://jira.mycompany.com/b
 This PR addresses concerns brought up in https://jira.mycompany.com/browse/JIRA-234.
 ```
 
-### How to allow Captain's Log to explicitly ignore an issue 
+### How to allow Captain's Log to explicitly ignore an issue
 
-There are many reasons that you would want to ignore an issue. One of the most common ones is when you have worked on multiple "sub-tasks" or "sub-tickets" that all roll into a single issue. It can be helpful to reference these in a pull request, especially if they close issues, like the github syntax allows you to do. However, you may just want Captain's Log to reference the "parent" issue on release. 
+There are many reasons that you would want to ignore an issue. One of the most common ones is when you have worked on multiple "sub-tasks" or "sub-tickets" that all roll into a single issue. It can be helpful to reference these in a pull request, especially if they close issues, like the github syntax allows you to do. However, you may just want Captain's Log to reference the "parent" issue on release.
 
-Ignoring an issue or multiple issues is as easy as placing these issues inside of a Captain's Log _"ignore block"_. It is a simple HTML comment block with two special key words, `icl` and `ecl`. This stands for `ignore captain's log` and `end captain's log` (ignore), respectively. 
+Ignoring an issue or multiple issues is as easy as placing these issues inside of a Captain's Log _"ignore block"_. It is a simple HTML comment block with two special key words, `icl` and `ecl`. This stands for `ignore captain's log` and `end captain's log` (ignore), respectively.
 
 Place this in your pull request template, or copy and paste it on a pr basis:
 

--- a/src/facades/ReleaseCommunicationFacade.js
+++ b/src/facades/ReleaseCommunicationFacade.js
@@ -82,7 +82,7 @@ class ReleaseCommunication {
     }, []);
 
     if (nonSquashedPRs.length) {
-      let prNumbersByCommit;
+      let prNumbersByCommit = [];
 
       // Should allow execution to continue for repositories that use a different merge method.
       try {

--- a/src/facades/ReleaseCommunicationFacade.js
+++ b/src/facades/ReleaseCommunicationFacade.js
@@ -82,7 +82,15 @@ class ReleaseCommunication {
     }, []);
 
     if (nonSquashedPRs.length) {
-      const prNumbersByCommit = await Promise.all(nonSquashedPRs.map(async commit => searchIssuesByCommitHandler(commit)));
+      let prNumbersByCommit;
+
+      // Should allow execution to continue for repositories that use a different merge method.
+      try {
+        prNumbersByCommit = await Promise.all(nonSquashedPRs.map(async commit => searchIssuesByCommitHandler(commit)));
+      } catch (e) {
+        console.log('Unable to retreive issues by commit. Check if API limit was exceeded.', e);
+      }
+
       // There should only ever be one issue for a commit
       prNumbersByCommit.forEach(pr => pullRequestNumbers.push(idx(pr, _ => _.items[0].number)));
     }
@@ -99,7 +107,7 @@ class ReleaseCommunication {
       const stripIgnoreTickets = body.replace(STRIP_IGNORE_TICKETS, '');
       const noCommentBody = stripIgnoreTickets.replace(PR_TEMPLATE_COMMENT_REGEX, '');
 
-      const ticketGroups = await ticketFinder(noCommentBody);
+      const ticketGroups = await ticketFinder({ ...pr, body: noCommentBody });
 
       return {
         number: pr.number,

--- a/src/utils/ticketFinder/__tests__/ticketFinder.test.js
+++ b/src/utils/ticketFinder/__tests__/ticketFinder.test.js
@@ -9,7 +9,7 @@ const {
 
 describe('ticketFinder', () => {
   it('should find tickets for all finders given a message body', async () => {
-    const tickets = await ticketFinder(mockBodyWithTickets);
+    const tickets = await ticketFinder({ body: mockBodyWithTickets });
 
     expect(tickets).toEqual({
       github: {
@@ -28,7 +28,7 @@ describe('ticketFinder', () => {
   });
 
   it('should find Jira tickets in brackets in given a message body', async () => {
-    const tickets = await ticketFinder(mockBodyWithTicketsInBrackets);
+    const tickets = await ticketFinder({ body: mockBodyWithTicketsInBrackets });
 
     expect(tickets).toEqual({
       github: { name: 'github', tickets: [] },
@@ -36,14 +36,32 @@ describe('ticketFinder', () => {
     });
   });
 
+  it('should find Jira ticket when there are tickets in the body and in the branch name', async () => {
+    const tickets = await ticketFinder({ body: mockBodyWithTicketsInBrackets, head: { ref: 'JIRA-123' } });
+
+    expect(tickets).toEqual({
+      github: { name: 'github', tickets: [] },
+      jira: { name: 'jira', tickets: [{ name: 'CAT-123' }, { name: 'JIRA-123' }] },
+    });
+  });
+
+  it('should find Jira ticket when there are tickets in the branch name only', async () => {
+    const tickets = await ticketFinder({ body: mockBodyWithNothing, head: { ref: 'therynamo/JIRA-123' } });
+
+    expect(tickets).toEqual({
+      github: { name: 'github', tickets: [] },
+      jira: { name: 'jira', tickets: [{ name: 'JIRA-123' }] },
+    });
+  });
+
   it('should not find things that look almost like tickets in given a message body', async () => {
-    const tickets = await ticketFinder(mockBodyWithTicketLikeThings);
+    const tickets = await ticketFinder({ body: mockBodyWithTicketLikeThings });
 
     expect(tickets).toEqual({ github: { name: 'github', tickets: [] }, jira: { name: 'jira', tickets: [] } });
   });
 
   it('should find multiple tickets for all finders given a message body', async () => {
-    const tickets = await ticketFinder(mockBodyWithMultipleTickets);
+    const tickets = await ticketFinder({ body: mockBodyWithMultipleTickets });
 
     expect(tickets).toEqual({
       github: {
@@ -68,7 +86,7 @@ describe('ticketFinder', () => {
   });
 
   it('should handle no tickets in a body', async () => {
-    const tickets = await ticketFinder(mockBodyWithNothing);
+    const tickets = await ticketFinder({ body: mockBodyWithNothing });
 
     expect(tickets).toEqual({ github: { name: 'github', tickets: [] }, jira: { name: 'jira', tickets: [] } });
   });

--- a/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
+++ b/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
@@ -125,7 +125,7 @@ describe('github finder', () => {
       ],
       name: 'github',
     };
-    expect(githubFinder(body)).toEqual(expectation);
+    expect(githubFinder({ body })).toEqual(expectation);
   });
 
   it('should return no tickets if there are no ticket types', () => {

--- a/src/utils/ticketFinder/finders/github/index.js
+++ b/src/utils/ticketFinder/finders/github/index.js
@@ -21,7 +21,9 @@ const GITHUB_CLOSE_REGEX = new RegExp(CLOSE_ISSUE_SYNTAX, 'gm');
 const GITHUB_CLOSE_NUMBER_REGEX = new RegExp(CLOSE_SYNTAX_NUMBER, 'gm');
 const GITHUB_CLOSE_PROJECT_REGEX = new RegExp(CLOSE_SYNTAX_PROJECT, 'gm');
 
-const githubFinder = (body) => {
+const githubFinder = (pr) => {
+  const { body = '' } = pr;
+
   const fullUrls = uniq(groupFinder(GITHUB_URL_REGEX, body) || []);
   const closeSyntaxUrls = uniq(groupFinder(GITHUB_CLOSE_REGEX, body) || []);
 

--- a/src/utils/ticketFinder/finders/jira/index.js
+++ b/src/utils/ticketFinder/finders/jira/index.js
@@ -1,15 +1,24 @@
+const idx = require('idx');
 const { uniq } = require('lodash');
 const nconf = require('nconf');
 
 const { groupFinder } = require('../../../');
 
-const regex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([[A-Z][A-Z0-9]*-[1-9][0-9]*)\]?/;
-const JIRA_REGEX = new RegExp(regex, 'g');
+const bodyRegex = nconf.get('regex') || /(?:\[|https:\/\/jira\..*\.com\/browse\/)([[A-Z][A-Z0-9]*-[1-9][0-9]*)\]?/;
+const branchRegex = /([[A-Z][A-Z0-9]*-[1-9][0-9]*)\]?/;
 
-const jiraFinder = (body) => {
+const JIRA_REGEX = new RegExp(bodyRegex, 'g');
+const JIRA_BRANCH_REGEX = new RegExp(branchRegex, 'g');
+
+const jiraFinder = (pr) => {
+  const { body = '' } = pr;
+
   const jiraTickets = uniq(groupFinder(JIRA_REGEX, body) || []);
 
-  const formattedTickets = jiraTickets.map(ticket => ({
+  const branchName = idx(pr, _ => _.head.ref);
+  const branchTicket = uniq(groupFinder(JIRA_BRANCH_REGEX, branchName) || []);
+
+  const formattedTickets = [...jiraTickets, ...branchTicket].map(ticket => ({
     name: ticket,
   }));
 

--- a/src/utils/ticketFinder/finders/jira/index.js
+++ b/src/utils/ticketFinder/finders/jira/index.js
@@ -15,7 +15,7 @@ const jiraFinder = (pr) => {
 
   const jiraTickets = uniq(groupFinder(JIRA_REGEX, body) || []);
 
-  const branchName = idx(pr, _ => _.head.ref);
+  const branchName = idx(pr, _ => _.head.ref) || '';
   const branchTicket = uniq(groupFinder(JIRA_BRANCH_REGEX, branchName) || []);
 
   const formattedTickets = [...jiraTickets, ...branchTicket].map(ticket => ({

--- a/src/utils/ticketFinder/index.js
+++ b/src/utils/ticketFinder/index.js
@@ -26,7 +26,7 @@ const getFinderFunctions = async () => {
 
 /**
  * Finds tickets in pull request based on pre-defined regexs
- * @param  {String}    pr pull request reqponse
+ * @param  {String}    pr pull request response
  * @return {Promise}      resolves to return an object with separated buckets that have matches
  */
 const ticketFinder = async (pr) => {

--- a/src/utils/ticketFinder/index.js
+++ b/src/utils/ticketFinder/index.js
@@ -25,16 +25,16 @@ const getFinderFunctions = async () => {
 };
 
 /**
- * Finds tickets in pull request bodies based on pre-defined regexs
- * @param  {String}  body pull request body
+ * Finds tickets in pull request based on pre-defined regexs
+ * @param  {String}    pr pull request reqponse
  * @return {Promise}      resolves to return an object with separated buckets that have matches
  */
-const ticketFinder = async (body) => {
+const ticketFinder = async (pr) => {
   const finders = await getFinderFunctions();
   const ticketMap = {};
 
   finders.forEach((finder) => {
-    const { name = null, tickets } = finder(body);
+    const { name = null, tickets } = finder(pr);
 
     if (!ticketMap[name]) {
       ticketMap[name] = {};


### PR DESCRIPTION
### Summary
This PR adds support for SCM integration with Jira. Jira has workflows that use a specific "branching convention" to associate github (and other SCM) pull requests to Jira tickets. That convention is outlined [here](https://confluence.atlassian.com/jirasoftwarecloud/referencing-issues-in-your-development-work-777002789.html).

Currently we're only supporting the `branch name` convention, if we receive asks for the commit convention we can modify CL to look at those as well. Ultimately we want to cut down on API calls to make sure our users do not exceed github api rate limits. 

- [x] Readme updates

### Issues
closes #41 