### PR TITLE
feat: Add Custom Slack Heading

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -23,11 +23,12 @@ Suggested configuration would be to place secrets in your CI configuration, and 
 
 **Optional Fields**
 
-- `jira_team_domain` - **Required** if you use the Jira issue tracker. Namespace of the Jira your workspace (e.g. `jira.myteamnamespace.com`, **myteamnamespace** would be the value for this key).
+- `enterprise_host` - **Required if** you use Enterprise Github. This is where you would supply the custom domain. (e.g. https://git.myCompany.com, `/api/v3` will be appended to this **do not include it for this value**).
+- `jira_team_domain` - **Required if** you use the Jira issue tracker. Namespace of the Jira your workspace (e.g. `jira.myteamnamespace.com`, **myteamnamespace** would be the value for this key).
 - `github_tag_id` - you can use this as regex to match on specific tags. Useful when your tags are not in chronological order (e.g. `-rc0`, `-rc1`, `-release`).
 - `slack_channel`/`SLACK_URL` - when using the API, you should use `slack_channel` to specify which room you'd like to post to. When using `SLACK_URL` you should **not** specify the room (i.e. `slack_channel`) because the room is already a part of the incoming webhook. ([Setting Up A Webhook (e.g. SLACK_URL)](https://api.slack.com/incoming-webhooks), [Setting Up A Slack Token](https://api.slack.com/docs/token-types#verification))
 - `teams` - a list of teams which allows you to organize the output of Captain's Log into meaningful chunks. (more below)
-- `enterprise_host` - **Required** if you use Enterprise Github. This is where you would supply the custom domain. (e.g. https://git.myCompany.com, `/api/v3` will be appended to this **do not include it for this value**).
+- `slack_message_heading` - you can provide a custom heading for the slack message that is posted, when using this field.
 
 ### Example
 

--- a/src/config.js
+++ b/src/config.js
@@ -64,6 +64,7 @@ if (process.env.NODE_ENV !== 'test') {
   nconf.set('slack:channel', process.env.PLUGIN_SLACK_CHANNEL);
   nconf.set('slack:token', process.env.SLACK_TOKEN);
   nconf.set('slack:channelUrl', process.env.SLACK_URL);
+  nconf.set('slack:messageHeading', process.env.PLUGIN_SLACK_MESSAGE_HEADING);
 
   // Jira
   nconf.set('jira:teamDomain', process.env.PLUGIN_JIRA_TEAM_DOMAIN);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const { populateMessages, getTeams, nameSort, formatMessages, generateSlackForma
 
 const defaultTeam = Team();
 
-const createAttachment = (hasMessages, { owner, repo, teamList }) => {
+const createAttachment = (hasMessages, { owner, repo, teamList, config }) => {
   let message = EMPTY_MESSAGE(owner, repo);
   let attachments = [];
   let subChannelAttachments = [];
@@ -19,7 +19,8 @@ const createAttachment = (hasMessages, { owner, repo, teamList }) => {
   }
 
   // add all the PRs if there are any
-  message = DEFAULT_HEADING(owner, repo);
+  const customHeading = config.get('slack:messageHeading');
+  message = customHeading || DEFAULT_HEADING(owner, repo);
   attachments = [];
   // team sub-channel attachments
   subChannelAttachments = [];

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,9 @@ module.exports = async function App(config) {
     owner,
     repo,
     teamList,
+    config
   });
+
 
   logger.info(`\n Slack Formatter Url. CMD+Click to open in your default browser \n \n ${generateSlackFormatterUrl(attachments)}`);
 


### PR DESCRIPTION
closes #54 

This adds a single field to the configuration called `slack_message_heading`. You can use this field to populate the Captain's Log heading with whatever you would like. 

Note: when #55 is merged, we'll need to update this pull request or have a subsequent pull request that will add this field to the external config. 