### PR TITLE
Add New Slack Heading To .captains.yml

### DIFF
--- a/src/utils/__tests__/initializeCaptainsConfig.test.js
+++ b/src/utils/__tests__/initializeCaptainsConfig.test.js
@@ -33,6 +33,7 @@ describe('initializeCaptainsConfig', () => {
       'slack:channel',
       'slack:token',
       'slack:channelUrl',
+      'slack:messageHeading',
       'jira:teamDomain',
     ].forEach((call, i) => expect(config.set.mock.calls[i][0]).toEqual(call));
   });

--- a/src/utils/initializeCaptainsConfig.js
+++ b/src/utils/initializeCaptainsConfig.js
@@ -29,6 +29,7 @@ const initialize = config => {
     slack_url,
     jira_team_domain,
     teams,
+    slack_message_heading,
   } = conf;
 
   // Github
@@ -46,6 +47,7 @@ const initialize = config => {
   config.set('slack:channel', slack_channel);
   config.set('slack:token', slack_token);
   config.set('slack:channelUrl', slack_url);
+  config.set('slack:messageHeading', slack_message_heading);
 
   // Jira
   config.set('jira:teamDomain', jira_team_domain);


### PR DESCRIPTION
Related to #54 

Just adding this to the `.captains.yml` that was added with #55. 