### PR TITLE
fix: Captains yml Broke

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,20 @@
 {
-  "extends": ["airbnb", "plugin:prettier/recommended"],
+  "extends": [
+    "airbnb",
+    "plugin:prettier/recommended"
+  ],
   "env": {
     "jest": true
   },
   "rules": {
     "arrow-parens": "off",
-    "max-len": ["error", 150],
+    "max-len": [
+      "error",
+      150
+    ],
     "no-debugger": "off",
     "camelcase": "off",
-    "object-curly-newline": "off"
+    "object-curly-newline": "off",
+    "consistent-return": "off"
   }
 }

--- a/.github/workflows/captains-test.yml
+++ b/.github/workflows/captains-test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-
+    name: Run Tests
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -5,7 +5,7 @@ There are two options for configuration:
 - use the `.drone.yml` and create a build step with the configuration values required (listed below).
 - place a `.captains.yml` file at the root of your directory. Place any required configuration in there. (**note**, you will still need a _Captain's Log build step_, it just will not have any of the configuration values listed there.)
 
-Both are usable, and at the same time. The `.captains.yml` will overwrite any variable that is in an `environment variable` (aka `.drone.yml` configurations).
+Both are usable, and at the same time. Any environment variable set (e.g. by your ci server) will overwrite any values in the `.captains.yml`. 
 
 Suggested configuration would be to place secrets in your CI configuration, and then have all other Captain's Log configurations in the `.captain.yml`. 
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -5,7 +5,7 @@ There are two options for configuration:
 - use the `.drone.yml` and create a build step with the configuration values required (listed below).
 - place a `.captains.yml` file at the root of your directory. Place any required configuration in there. (**note**, you will still need a _Captain's Log build step_, it just will not have any of the configuration values listed there.)
 
-Both are usable, and at the same time. Any environment variable set (e.g. by your ci server) will overwrite any values in the `.captains.yml`. 
+Both are usable, and at the same time. Any environment variable set (e.g. by your CI server) will overwrite any values in the `.captains.yml`. 
 
 Suggested configuration would be to place secrets in your CI configuration, and then have all other Captain's Log configurations in the `.captain.yml`. 
 

--- a/src/config.js
+++ b/src/config.js
@@ -49,28 +49,45 @@ nconf.set('development', process.env.NODE_ENV === DEVELOPMENT);
 nconf.set('regexp', process.env.PLUGIN_REGEXP);
 
 if (process.env.NODE_ENV !== 'test') {
+  // Initialize captains.yml
+  const captainsConfig = initialize() || {};
+  const {
+    enterprise_host,
+    github_host,
+    github_owner,
+    github_repo,
+    github_tag_id,
+    github_token,
+    slack_channel,
+    slack_token,
+    slack_url,
+    jira_team_domain,
+    teams,
+    slack_message_heading,
+  } = captainsConfig;
+
   // Github
-  nconf.set('github:domain', process.env.PLUGIN_ENTERPRISE_HOST);
-  nconf.set('github:host', process.env.PLUGIN_GITHUB_HOST);
-  nconf.set('github:owner', process.env.PLUGIN_GITHUB_OWNER);
-  nconf.set('github:repo', process.env.PLUGIN_GITHUB_REPO);
-  nconf.set('github:tagId', process.env.PLUGIN_GITHUB_TAG_ID);
-  nconf.set('github:token', process.env.GITHUB_TOKEN);
+  nconf.set('github:domain', process.env.PLUGIN_ENTERPRISE_HOST || enterprise_host);
+  nconf.set('github:host', process.env.PLUGIN_GITHUB_HOST || github_host);
+  nconf.set('github:owner', process.env.PLUGIN_GITHUB_OWNER || github_owner);
+  nconf.set('github:repo', process.env.PLUGIN_GITHUB_REPO || github_repo);
+  nconf.set('github:tagId', process.env.PLUGIN_GITHUB_TAG_ID || github_tag_id);
+
+  if (!process.env.GITHUB_TOKEN && !github_token)
+    throw Error("Captain's log requires a Github Token to run. Please verify you've set one and try again.");
+  nconf.set('github:token', process.env.GITHUB_TOKEN || github_token);
 
   // Team Configuration
-  nconf.set('teams', process.env.PLUGIN_TEAMS);
+  nconf.set('teams', process.env.PLUGIN_TEAMS || teams);
 
   // Slack
-  nconf.set('slack:channel', process.env.PLUGIN_SLACK_CHANNEL);
-  nconf.set('slack:token', process.env.SLACK_TOKEN);
-  nconf.set('slack:channelUrl', process.env.SLACK_URL);
-  nconf.set('slack:messageHeading', process.env.PLUGIN_SLACK_MESSAGE_HEADING);
+  nconf.set('slack:channel', process.env.PLUGIN_SLACK_CHANNEL || slack_channel);
+  nconf.set('slack:token', process.env.SLACK_TOKEN || slack_token);
+  nconf.set('slack:channelUrl', process.env.SLACK_URL || slack_url);
+  nconf.set('slack:messageHeading', process.env.PLUGIN_SLACK_MESSAGE_HEADING || slack_message_heading);
 
   // Jira
-  nconf.set('jira:teamDomain', process.env.PLUGIN_JIRA_TEAM_DOMAIN);
-
-  // Initialize captains.yml
-  initialize(nconf);
+  nconf.set('jira:teamDomain', process.env.PLUGIN_JIRA_TEAM_DOMAIN || jira_team_domain);
 }
 
 module.exports = nconf;

--- a/src/config.js
+++ b/src/config.js
@@ -67,27 +67,27 @@ if (process.env.NODE_ENV !== 'test') {
   } = captainsConfig;
 
   // Github
-  nconf.set('github:domain', process.env.PLUGIN_ENTERPRISE_HOST || enterprise_host);
-  nconf.set('github:host', process.env.PLUGIN_GITHUB_HOST || github_host);
-  nconf.set('github:owner', process.env.PLUGIN_GITHUB_OWNER || github_owner);
-  nconf.set('github:repo', process.env.PLUGIN_GITHUB_REPO || github_repo);
-  nconf.set('github:tagId', process.env.PLUGIN_GITHUB_TAG_ID || github_tag_id);
+  nconf.set('github:domain', enterprise_host);
+  nconf.set('github:host', github_host);
+  nconf.set('github:owner', github_owner);
+  nconf.set('github:repo', github_repo);
+  nconf.set('github:tagId', github_tag_id);
 
-  if (!process.env.GITHUB_TOKEN && !github_token)
+  if (github_token)
     throw Error("Captain's log requires a Github Token to run. Please verify you've set one and try again.");
-  nconf.set('github:token', process.env.GITHUB_TOKEN || github_token);
+  nconf.set('github:token', github_token);
 
   // Team Configuration
-  nconf.set('teams', process.env.PLUGIN_TEAMS || teams);
+  nconf.set('teams', teams);
 
   // Slack
-  nconf.set('slack:channel', process.env.PLUGIN_SLACK_CHANNEL || slack_channel);
-  nconf.set('slack:token', process.env.SLACK_TOKEN || slack_token);
-  nconf.set('slack:channelUrl', process.env.SLACK_URL || slack_url);
-  nconf.set('slack:messageHeading', process.env.PLUGIN_SLACK_MESSAGE_HEADING || slack_message_heading);
+  nconf.set('slack:channel', slack_channel);
+  nconf.set('slack:token', slack_token);
+  nconf.set('slack:channelUrl', slack_url);
+  nconf.set('slack:messageHeading', slack_message_heading);
 
   // Jira
-  nconf.set('jira:teamDomain', process.env.PLUGIN_JIRA_TEAM_DOMAIN || jira_team_domain);
+  nconf.set('jira:teamDomain', jira_team_domain);
 }
 
 module.exports = nconf;

--- a/src/utils/__tests__/initializeCaptainsConfig.test.js
+++ b/src/utils/__tests__/initializeCaptainsConfig.test.js
@@ -7,7 +7,20 @@ describe('initializeCaptainsConfig', () => {
   it('should not set any config values if there is no `captains.yml` file', () => {
     findUp.sync = jest.fn(() => undefined);
 
-    expect(initialize()).toEqual(undefined);
+    expect(initialize()).toEqual({
+      enterprise_host: undefined,
+      github_host: undefined,
+      github_owner: undefined,
+      github_repo: undefined,
+      github_tag_id: undefined,
+      github_token: undefined,
+      jira_team_domain: undefined,
+      slack_channel: undefined,
+      slack_message_heading: undefined,
+      slack_token: undefined,
+      slack_url: undefined,
+      teams: undefined,
+    });
   });
 
   it('should read from a `.captains.yml` file if one exists', () => {

--- a/src/utils/initializeCaptainsConfig.js
+++ b/src/utils/initializeCaptainsConfig.js
@@ -2,7 +2,7 @@ const findUp = require('find-up');
 const { readFileSync } = require('fs');
 const { safeLoad } = require('js-yaml');
 
-const initialize = config => {
+const initialize = () => {
   let conf = {};
 
   try {
@@ -13,9 +13,6 @@ const initialize = config => {
     console.log('Could not find `captains.yml` file, reverting to environment variables');
     return;
   }
-
-  // if there are not config values, just return
-  if (!Object.keys(conf).length) return;
 
   const {
     enterprise_host,
@@ -32,25 +29,29 @@ const initialize = config => {
     slack_message_heading,
   } = conf;
 
-  // Github
-  config.set('github:domain', enterprise_host);
-  config.set('github:host', github_host);
-  config.set('github:owner', github_owner);
-  config.set('github:repo', github_repo);
-  config.set('github:tagId', github_tag_id);
-  config.set('github:token', github_token);
+  const captainsConfig = {
+    // Github
+    enterprise_host: process.env.PLUGIN_ENTERPRISE_HOST || enterprise_host,
+    github_host: process.env.PLUGIN_GITHUB_HOST || github_host,
+    github_owner: process.env.PLUGIN_GITHUB_OWNER || github_owner,
+    github_repo: process.env.PLUGIN_GITHUB_REPO || github_repo,
+    github_tag_id: process.env.PLUGIN_GITHUB_TAG_ID || github_tag_id,
+    github_token: process.env.GITHUB_TOKEN || github_token,
 
-  // Team Configuration
-  config.set('teams', teams);
+    // Team Configuration
+    teams: process.env.PLUGIN_TEAMS || teams,
 
-  // Slack
-  config.set('slack:channel', slack_channel);
-  config.set('slack:token', slack_token);
-  config.set('slack:channelUrl', slack_url);
-  config.set('slack:messageHeading', slack_message_heading);
+    // Slack
+    slack_channel: process.env.PLUGIN_SLACK_CHANNEL || slack_channel,
+    slack_token: process.env.SLACK_TOKEN || slack_token,
+    slack_url: process.env.SLACK_URL || slack_url,
+    slack_message_heading: process.env.PLUGIN_SLACK_MESSAGE_HEADING || slack_message_heading,
 
-  // Jira
-  config.set('jira:teamDomain', jira_team_domain);
+    // Jira
+    jira_team_domain: process.env.PLUGIN_JIRA_TEAM_DOMAIN || jira_team_domain,
+  };
+
+  return captainsConfig;
 };
 
 module.exports = initialize;

--- a/src/utils/initializeCaptainsConfig.js
+++ b/src/utils/initializeCaptainsConfig.js
@@ -11,7 +11,6 @@ const initialize = () => {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log('Could not find `captains.yml` file, reverting to environment variables');
-    return;
   }
 
   const {


### PR DESCRIPTION
In #52 I broke using Captain's Log with a `.drone.yml` and ` .captains.yml`. This didn't impact anyone who didn't switch over, but for those who did, they were unable to receive release notes. 

Had I wrote the test that @jmccann so graciously asked me to write, this would have been caught. I should have listened 😄. The tests in this PR should cover us. 