### PR TITLE
refactor: enhance github url regex

### DIFF
--- a/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
+++ b/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
@@ -15,7 +15,9 @@ resolved super/duper/#11
 
 https://github.com/example_user/example_project/issues/3
 https://github.com/example_user/example_project/issues/4
+https://github.com/example_user/example_project/issues/5#some-hash
 https://git.myenterprise.com/example_user/example_project/issues/5
+https://git.subdomain.myenterprise.com/example_user/example_project/issues/5
 https://www.github.com/example_user/example_project/issues/6
 https://github.com/example_user/example_project/issues/7
 https://github.com/example_user/example_project/issues/8
@@ -39,7 +41,19 @@ describe('github finder', () => {
           name: '4',
         },
         {
+          fullLinkedUrl: 'https://github.com/example_user/example_project/issues/5',
+          project: 'example_user/example_project',
+          issueNumber: '5',
+          name: '5',
+        },
+        {
           fullLinkedUrl: 'https://git.myenterprise.com/example_user/example_project/issues/5',
+          project: 'example_user/example_project',
+          issueNumber: '5',
+          name: '5',
+        },
+        {
+          fullLinkedUrl: 'https://git.subdomain.myenterprise.com/example_user/example_project/issues/5',
           project: 'example_user/example_project',
           issueNumber: '5',
           name: '5',
@@ -128,12 +142,39 @@ describe('github finder', () => {
     expect(githubFinder({ body })).toEqual(expectation);
   });
 
+  it('should find ticket with period at end of URL', () => {
+    const PRBody = `
+      ## Summary
+
+
+      https://git.you.com/wow/woohoo/issues/27158.
+
+      ### Addresses issue
+
+      prod issue
+      ### Steps to reproduce & screenshots/GIFs
+    `;
+    const expectation = {
+      tickets: [
+        {
+          fullLinkedUrl: 'https://git.you.com/wow/woohoo/issues/27158',
+          project: 'wow/woohoo',
+          issueNumber: '27158',
+          name: '27158',
+        },
+      ],
+      name: 'github',
+    };
+
+    expect(githubFinder({ body: PRBody })).toEqual(expectation);
+  });
+
   it('should return 2 tickets, not one, if they grouped together by only words or whitespace', () => {
     const PRBody = `
       ## Summary
 
 
-      https://git.you.com/wow/woohoo/issues/27158 and https://git.you.com/wow/woohoo/issue/27166
+      https://git.you.com/wow/woohoo/issues/27158 and https://git.you.com/wow/woohoo/issues/27166
 
       ### Addresses issue
 
@@ -149,7 +190,7 @@ describe('github finder', () => {
           name: '27158',
         },
         {
-          fullLinkedUrl: 'https://git.you.com/wow/woohoo/issue/27166',
+          fullLinkedUrl: 'https://git.you.com/wow/woohoo/issues/27166',
           project: 'wow/woohoo',
           issueNumber: '27166',
           name: '27166',
@@ -176,6 +217,26 @@ describe('github finder', () => {
       tickets: [],
       name: 'github',
     };
+    expect(githubFinder({ body: PRBody })).toEqual(expectation);
+  });
+
+  it('should not think other GitHub URL is a ticket', () => {
+    const PRBody = `
+      ## Summary
+
+
+      https://git.you.com/wow/woohoo/tree/main/config/123
+
+      ### Addresses issue
+
+      prod issue
+      ### Steps to reproduce & screenshots/GIFs
+    `;
+    const expectation = {
+      tickets: [],
+      name: 'github',
+    };
+
     expect(githubFinder({ body: PRBody })).toEqual(expectation);
   });
 

--- a/src/utils/ticketFinder/finders/github/index.js
+++ b/src/utils/ticketFinder/finders/github/index.js
@@ -7,7 +7,7 @@ const githubDomain = config.get('github:domain') || 'https://github.com';
 const owner = config.get('github:owner');
 const repo = config.get('github:repo');
 
-const GITHUB_QUALIFIED_URL = /(https:\/\/(?:www.git|git)(?:\.\w+|\w+)\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/[^pull]+\w+\/\d+)/;
+const GITHUB_QUALIFIED_URL = /(https:\/\/(?:www.git|git)[^\s]*(\.[^\s]+)+\/[^\s]+\/[^\s]+\/issues\/\d+)/;
 const GITHUB_QUALIFIED_NUMBER_URL = /https:\/\/(?:www.git|git).*\..+\/(\d+)/;
 const CLOSE_ISSUE_SYNTAX = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s(\S.*\/\S.*#\d+|#\d+)/;
 const CLOSE_SYNTAX_NUMBER = /#(\d+)/;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enhances the GitHub URL regex to only match issue URLs rather than any GitHub URL with digits in the path, to support multiple subdomains for some companies, to not limit supported domain and owner and repo names to basic A-Z character set but to support other ASCII or Unicode characters, etc. - all while retaining the fix from #86, mostly by using a `[^\s]` pattern to avoid matching whitespace.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were some false positives and some cases where existing regex wouldn't quite work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] unit tests?

Existing unit tests pass. Added some more unit tests that fail without the changes but pass with.

Without changes:
<img width="580" alt="Screen Shot 2020-10-26 at 6 46 20 AM" src="https://user-images.githubusercontent.com/615381/97169082-735cfe80-1757-11eb-8835-29d84988d19d.png">

With changes:
<img width="800" alt="Screen Shot 2020-10-26 at 6 49 21 AM" src="https://user-images.githubusercontent.com/615381/97169099-79eb7600-1757-11eb-9165-a973a77cfd62.png">

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updating repository quality of life, like deps, linting, etc.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
