### PR TITLE
fix: support capitalized github keywords

### DIFF
--- a/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
+++ b/src/utils/ticketFinder/finders/github/__tests__/githubFinder.test.js
@@ -9,6 +9,7 @@ fixes #14
 fixed #15
 resolve #1
 resolves #13
+Resolves #16
 resolved #20
 resolves super/duper/#10
 resolved super/duper/#11
@@ -117,6 +118,12 @@ describe('github finder', () => {
           project: 'test_owner/test_repo',
           issueNumber: '15',
           name: '15',
+        },
+        {
+          fullLinkedUrl: 'https://github.com/test_owner/test_repo/issues/16',
+          project: 'test_owner/test_repo',
+          issueNumber: '16',
+          name: '16',
         },
         {
           fullLinkedUrl: 'https://github.com/test_owner/test_repo/issues/20',

--- a/src/utils/ticketFinder/finders/github/index.js
+++ b/src/utils/ticketFinder/finders/github/index.js
@@ -17,7 +17,7 @@ const OWNER_PROJECT = /https:\/\/(?:www.git|git).*\.com\/(.+)?\/.+\/\d+$/;
 const GITHUB_URL_REGEX = new RegExp(GITHUB_QUALIFIED_URL, 'gm');
 const GITHUB_URL_NUMBER_REGEX = new RegExp(GITHUB_QUALIFIED_NUMBER_URL, 'gm');
 const GITHUB_PROJECT_REGEX = new RegExp(OWNER_PROJECT, 'gm');
-const GITHUB_CLOSE_REGEX = new RegExp(CLOSE_ISSUE_SYNTAX, 'gm');
+const GITHUB_CLOSE_REGEX = new RegExp(CLOSE_ISSUE_SYNTAX, 'gmi');
 const GITHUB_CLOSE_NUMBER_REGEX = new RegExp(CLOSE_SYNTAX_NUMBER, 'gm');
 const GITHUB_CLOSE_PROJECT_REGEX = new RegExp(CLOSE_SYNTAX_PROJECT, 'gm');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds case-insensitivity to the regular expression that looks for GitHub keywords (`Close(s)`, `Fix(es)`, `Resolve(s)`) in PR descriptions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed (I think) that we were possibly missing detection of capitalized GitHub keywords (`Close(s)`, `Fix(es)`, `Resolve(s)`). This [is supported by GitHub](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) so we should support it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] unit tests?

:x: Failing before:

![Screen Shot 2021-02-03 at 9 02 45 AM](https://user-images.githubusercontent.com/615381/106766695-b7398c80-65ff-11eb-8cd2-a1b6f57ddf16.png)

✅ Passing after:

![Screen Shot 2021-02-03 at 9 11 00 AM](https://user-images.githubusercontent.com/615381/106766750-c6203f00-65ff-11eb-814a-7859352a19af.png)

## Screenshots (if appropriate):

![Screen Shot 2021-02-03 at 9 09 04 AM](https://user-images.githubusercontent.com/615381/106766559-9c671800-65ff-11eb-834b-8c5c685f63b5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updating repository quality of life, like deps, linting, etc.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
