### PR TITLE
fix: dont log channel url in error message

### DIFF
--- a/src/handlers/postMessageHandler.js
+++ b/src/handlers/postMessageHandler.js
@@ -21,7 +21,7 @@ module.exports = async function postMessage({ blocks, channel = null, text, chan
     try {
       await fetch(channelUrl, postOptions(blocks, text, channel));
     } catch (e) {
-      console.error(`Channel not found at URL: ${channelUrl}`, e);
+      console.error(`Channel not found:`, e);
     }
 
     return response;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
resolves https://github.com/target/captains-log/issues/115

## Motivation and Context
I saw a slack token url secret being logged in CI after a task failed, so wanted to make sure we aren't logging secrets.

## How Has This Been Tested?
minor change in logging

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (updating repository quality of life, like deps, linting, etc.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
